### PR TITLE
Change ProseMirror Dependency from SSH to HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react": "^0.13.3"
   },
   "dependencies": {
-    "prosemirror": "git@github.com:ProseMirror/prosemirror.git"
+    "prosemirror": "git+https://github.com/ProseMirror/prosemirror.git"
   },
   "devDependencies": {
     "babel-core": "^5.8.25",


### PR DESCRIPTION
to allow for anonymous access to the repo.

This currently makes my [travis builds fail](https://travis-ci.org/beavyHQ/beavy/builds/84796539), as it isn't configured to use ssh with github ...
