### PR TITLE
don't depend on prosemirror directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ You can clone this repo or run:
 npm install react-prosemirror
 ```
 
+You'll also need to bring your own copy of ProseMirror, so install that too:
+
+```sh
+npm install prosemirror
+```
+
 If your target environment doesn't natively support `Object.assign`, you may need to use some sort of polyfill such as [babel-polyfill](https://babeljs.io/docs/usage/polyfill/).
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
     "react": "~0.14.0",
     "react-dom": "~0.14.0"
   },
-  "dependencies": {
-    "prosemirror": ">=0.2.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-cli": "^6.4.0",
     "babel-core": "^6.1.4",
@@ -51,6 +49,7 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-webpack": "^1.7.0",
     "phantomjs-prebuilt": "^2.1.3",
+    "prosemirror": ">=0.2.0",
     "react": "^0.14.7",
     "react-addons-test-utils": "^0.14.7",
     "react-dom": "^0.14.7",


### PR DESCRIPTION
I believe this should fix https://github.com/tgecho/react-prosemirror/issues/12 and https://github.com/tgecho/react-prosemirror/issues/14!
